### PR TITLE
Maintain number of comments shown on reload

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/DeleteServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeleteServlet.java
@@ -1,0 +1,37 @@
+package com.google.sps.servlets;
+
+import com.google.sps.data.Comment;
+import java.util.Date;
+import com.google.gson.Gson;
+import java.io.IOException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.ArrayList;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Query.SortDirection;
+
+/** Servlet that deletes some data. */
+@WebServlet("/delete-data")
+public class DeleteServlet extends HttpServlet {
+
+  @Override
+  public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+      
+      Query query = new Query("Comment").addSort("timestamp", SortDirection.DESCENDING);
+      DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+      PreparedQuery results = datastore.prepare(query);
+
+      ArrayList<Entity> entities = new ArrayList<>();
+      for (Entity entity : results.asIterable()) {
+          datastore.delete(entity.getKey());
+      }
+      response.getWriter().print("empty response");
+  }
+}

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -207,44 +207,21 @@
 
         <section id="comments">
           <h3>arrington's friends comments</h3>
-          <p>displaying <span class="num">4</span> of <span class="num">12345</span> comments</p>
+          <form action="/data?display=10" method="POST">
+                displaying 
+                <select name="num-comments" id="num-comments" onchange="this.form.submit()">
+                <option>10</option>
+                <option>25</option>
+                <option>50</option></select> comments.
+          </form>
           <table id="comment-section">
-                <tr>
-                    <th>charlie brown <img class="center" src="images/charlie.jpg" width="200" height="200"></th>
-                    <td id="text">arrington is super cool and the most amazing person on the planet.</td>
-                </tr>
-                <tr>
-                    <th>woodstock <img class="center" src="images/woodstock.jpg" width="200" height="200"></th>
-                    <td>*bird noises*</td>
-                </tr>
-                <tr>
-                    <th>lucy <img class="center" src="images/lucy.jpg" width="200" height="200"></th>
-                    <td>i'll hold the ball and you kick it. it's thanksgiving</td>
-                </tr>
-                <tr>
-                    <th>
-                        charlie brown's mom <img class="center" src="images/not-found.png" width="200" height="200">
-                        </th>
-                    <td>
-                        wah wah wah wah wah waah wah wah. wah wah waaah wah wah wah wah waah wahh wah. 
-                        wah wah wah wah wah waah wah wah waaah wah wah. wah wah wah waah wah wah wahwah waaah wah wah wah.
-                         wah waah wah.
-                         </td>
-                </tr>
             </table>
             <form action="/data" method="POST">
                 <p>Enter your name:</p>
-                <input type="text" name="name">
+                <input type="text" name="name" required>
                 <p>Add a comment:</p>
-                <input type="text" name="comment">
+                <input type="text" name="comment" required>
                 <br/><br/>
-                displaying 
-                <select name="display-num" size="3">
-                <option selected>10</option>
-                <option>25</option>
-                <option>50</option>comments.
-            <br/>
-            <br/>
             <input type="submit" />
     </form>
         </section>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -207,7 +207,7 @@
 
         <section id="comments">
           <h3>arrington's friends comments</h3>
-          <form action="/data?display=10" method="POST">
+          <form action="/data" method="POST">
                 displaying 
                 <select name="num-comments" id="num-comments" onchange="this.form.submit()">
                 <option>10</option>

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -41,6 +41,8 @@ function age() {
 
 function getMessages() {
     age() // you can only have one function in the onload attribute
+    getDropdownVal()
+    
     console.log("Fetching text.");
     const responsePromise = fetch("/data");
     responsePromise.then(handleResponse);
@@ -78,4 +80,18 @@ function makeComment(heading, content) {
     row.appendChild(td)
 
     return row;
+}
+
+function getDropdownVal() {
+    const dropdown = document.getElementById("num-comments");
+    dropdown.onchange = changeDropdownVal;
+    if (localStorage["num-comments"]) {
+        dropdown.value = localStorage["num-comments"];
+    }   
+}
+
+function changeDropdownVal() {
+    const dropdown = document.getElementById("num-comments");
+    localStorage["num-comments"] = dropdown.value;
+    this.form.submit();
 }


### PR DESCRIPTION
This PR makes it so the number of comments does not change when the page is reloaded.

Before, if the page was reloaded, the value of the comment dropdown would reset to 10 even if the actual number of comments shown was different. This made it impossible to show 10 comments again because dropdown boxes don't let you reselect the option that is currently selected. With this update, the value of the dropdown box is retained on reload.